### PR TITLE
[bt#6768] Fixes crash when logging a note over an object that doesn't have an operating_unit_id.

### DIFF
--- a/mail_operating_unit/wizard/mail_compose_message_ext.py
+++ b/mail_operating_unit/wizard/mail_compose_message_ext.py
@@ -20,6 +20,6 @@ class MailComposeMessageExt(models.TransientModel):
         res_id = result.get('res_id', False)
         if model and res_id:
             model_object = self.env[model].browse(res_id)
-            if model_object.operating_unit_id:
+            if hasattr(model_object, 'operating_unit_id'):
                 result['operating_unit_id'] = model_object.operating_unit_id.id
         return result


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> <div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=6768">[bt#6768] Fwd: FW: CW236: Please check this lot assigned to you</a></li>
 </ul><!-- BT_AUTOLINKS_END -->