### PR TITLE
[bt#8046] Added record rule to filter inventory adjustments for locations having the operating unit.

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -45,6 +45,20 @@
         <field eval="0" name="perm_create"/>
     </record>
 
+    <record id="ir_rule_stock_inventory_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="stock.model_stock_inventory"/>
+        <field name="domain_force">['|',
+            ('location_id.operating_unit_id', 'in', user.operating_unit_ids.ids),
+            ('location_id.operating_unit_id', '=', False)]
+        </field>
+        <field name="name">Stock Inventory having locations from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
     <record id="ir_rule_stock_move_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_move"/>
         <field name="domain_force">['|',


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=8046">[bt#8046] Odoo Server Error due to Security Restrictions</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_operating_unit</td><td>.xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->