### PR TITLE
[t115272] Rules for operating units regarding stock.move.lines are taken from the associated stock.move.

### DIFF
--- a/product_operating_unit/__manifest__.py
+++ b/product_operating_unit/__manifest__.py
@@ -8,7 +8,7 @@
 {
     "name": "Operating Unit in Products",
     "summary": "Adds the concept of operating unit (OU) in products",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "author": "brain-tec AG, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/operating-unit",
@@ -18,6 +18,7 @@
     "data": [
         "security/product_template_security.xml",
         "views/product_template_view.xml",
+        "data/product_operating_unit_data.xml",
     ],
     "installable": True,
 }

--- a/product_operating_unit/data/product_operating_unit_data.xml
+++ b/product_operating_unit/data/product_operating_unit_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="main_product_operating_unit" model="operating.unit">
+        <field name="name">Main Product Operating Unit</field>
+        <field name="code">OUMP</field>
+        <field name="partner_id" ref="base.main_partner"/>
+    </record>
+</odoo>

--- a/product_operating_unit/tests/test_product_operating_unit.py
+++ b/product_operating_unit/tests/test_product_operating_unit.py
@@ -17,7 +17,8 @@ class TestProductOperatingUnit(common.TransactionCase):
         # groups
         self.group_stock_user = self.env.ref('stock.group_stock_user')
         # Main Operating Unit
-        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        self.ou1 = self.env.ref('product_operating_unit.'
+                                'main_product_operating_unit')
         # B2B Operating Unit
         self.b2b = self.env.ref('operating_unit.b2b_operating_unit')
         # Products

--- a/stock_operating_unit/__manifest__.py
+++ b/stock_operating_unit/__manifest__.py
@@ -12,7 +12,7 @@
               "Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/operating-unit",
-    "depends": ["stock", "account_operating_unit"],
+    "depends": ["stock", "account_operating_unit", "product"],
     "data": [
         "security/stock_security.xml",
         "data/stock_data.xml",

--- a/stock_operating_unit/__manifest__.py
+++ b/stock_operating_unit/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock with Operating Units",
     "summary": "Adds the concept of operating unit (OU) in stock management",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.2",
     "category": "Generic Modules/Sales & Purchases",
     "author": "Eficent, "
               "Serpent Consulting Services Pvt. Ltd., "

--- a/stock_operating_unit/model/stock_move.py
+++ b/stock_operating_unit/model/stock_move.py
@@ -9,7 +9,7 @@ class StockMove(models.Model):
     _inherit = 'stock.move'
 
     operating_unit_id = fields.Many2one('operating.unit',
-        compute="_compute_operating_unit_id",
+        compute="_compute_operating_unit_id", store=True,
         string='Source Location Operating Unit',
     )
     operating_unit_dest_id = fields.Many2one('operating.unit',

--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -121,8 +121,11 @@
     <record id="ir_rule_stock_move_line_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_move_line"/>
         <field name="domain_force">['|',
-            ('move_id.operating_unit_id','=',False),
-            ('move_id.operating_unit_id','in',user.operating_unit_ids.ids)]
+            ('move_id.location_id.operating_unit_id','=',False),
+            ('move_id.location_id.operating_unit_id','in',user.operating_unit_ids.ids),
+            '|',
+            ('move_id.location_dest_id.operating_unit_id','=',False),
+            ('move_id.location_dest_id.operating_unit_id','in',user.operating_unit_ids.ids)]
         </field>
         <field name="name">Stock move lines from allowed operating units according to stock move line</field>
         <field name="global" eval="True"/>

--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -103,4 +103,18 @@
         <field eval="1" name="perm_read"/>
         <field eval="0" name="perm_create"/>
     </record>
+
+    <record id="ir_rule_stock_move_line_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="stock.model_stock_move_line"/>
+        <field name="domain_force">['|',
+            ('move_id.operating_unit_id','=',False),
+            ('move_id.operating_unit_id','in',user.operating_unit_ids.ids)]
+        </field>
+        <field name="name">Stock move lines from allowed operating units according to stock move line</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
 </odoo>


### PR DESCRIPTION
**User Stories:** mt1739

**Notes for testing/deployment:** Update manually (if not done automatically) the module ```stock_operating_unit```.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=115272">[t115272] [MIUS] [DEV] [mt1739] USA: Mifroma - Inventory by Lot Report to Show Case Landed Costs for Case Items</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_operating_unit</td><td>.py, .xml</td></tr>
<tr><td>product_operating_unit</td><td>.py, .xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->