### PR TITLE
[bt#8565] Access error:

### DIFF
--- a/account_operating_unit/security/account_security.xml
+++ b/account_operating_unit/security/account_security.xml
@@ -43,7 +43,15 @@
 
     <record id="ir_rule_move_line_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="account.model_account_move_line"/>
-        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in', user.operating_unit_ids.ids)]
+        <field name="domain_force">[
+            '&amp;',
+              '|',
+                ('operating_unit_id','=',False),
+                ('operating_unit_id','in', user.operating_unit_ids.ids),
+              '|',
+                ('journal_id.operating_unit_id', '=', False),
+                ('journal_id.operating_unit_id', 'in', user.operating_unit_ids.ids)
+        ]
         </field>
         <field name="name">Move lines from allowed operating units</field>
         <field name="global" eval="True"/>


### PR DESCRIPTION
- The reconciliation widget raised access error when trying to access an account.move.line with an operating unit I can read, but with a journal whose operating unit I am not allowed to access

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=8565">[bt#8565] [#54] USA - Mifroma - Access Errors: Enter Payment</a></li>
</ul>
<!-- BT_AUTOLINKS_END -->