### PR TITLE
[bt#9933] Operating Units - Problems with Record Rules

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -19,7 +19,8 @@
 
     <record id="ir_rule_stock_picking_type_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_picking_type"/>
-        <field name="domain_force">['|',
+        <field name="domain_force">['|', '|',
+            ('warehouse_id','=', False),
             ('warehouse_id.operating_unit_id','=', False),
             ('warehouse_id.operating_unit_id','in',user.operating_unit_ids.ids)]
         </field>


### PR DESCRIPTION
Extended the rule to prevent future issues when there is no warehouse_id

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=9933">[bt#9933] Operating Units - Problems with Record Rules</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_operating_unit</td><td>.xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->