### PR TITLE
[t117247] Fixes the placement of the uninstall_hook so that account_operating_unit can be uninstalled.

### DIFF
--- a/account_operating_unit/__init__.py
+++ b/account_operating_unit/__init__.py
@@ -2,3 +2,12 @@
 
 from . import models
 from . import report
+
+from odoo.addons.account.models.account_payment \
+    import account_payment as AccountPaymentOrig
+
+
+def uninstall_hook(cr, registry):
+    # If the method was patched we revert it during runtime
+    if hasattr(AccountPaymentOrig._create_payment_entry, 'origin'):
+        AccountPaymentOrig._revert_method('_create_payment_entry')

--- a/account_operating_unit/models/__init__.py
+++ b/account_operating_unit/models/__init__.py
@@ -5,12 +5,3 @@ from . import account_journal
 from . import account_move
 from . import account_invoice
 from . import account_payment
-
-from odoo.addons.account.models.account_payment \
-    import account_payment as AccountPaymentOrig
-
-
-def uninstall_hook(cr, registry):
-    # If the method was patched we revert it during runtime
-    if hasattr(AccountPaymentOrig._create_payment_entry, 'origin'):
-        AccountPaymentOrig._revert_method('_create_payment_entry')


### PR DESCRIPTION




<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=117247">[t117247] Decoupling of mind_reports and account_invoice_multi_terms</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>account_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->