### PR TITLE
[t116909] Adding default operating unit for existing demo Sales Team

### DIFF
--- a/sales_team_operating_unit/__manifest__.py
+++ b/sales_team_operating_unit/__manifest__.py
@@ -5,7 +5,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Sales Team Operating Unit",
-    "version": "12.0.1.1.1",
+    "version": "12.0.1.1.2",
     "author": "Eficent, "
               "SerpentCS,"
               "Odoo Community Association (OCA)",
@@ -15,6 +15,7 @@
     "depends": ["sales_team", "operating_unit"],
     "data": [
         "security/crm_security.xml",
+        "demo/sales_team_demo.xml",
         "views/crm_team_view.xml",
     ],
     'installable': True,

--- a/sales_team_operating_unit/demo/sales_team_demo.xml
+++ b/sales_team_operating_unit/demo/sales_team_demo.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <data noupdate="0">
+        <record id="sales_team.team_sales_department" model="crm.team">
+            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=116909">[t116909] Travis with automatic tests</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sales_team_operating_unit</td><td>.py, .xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->