### PR TITLE
[t119559] Index the m2o 'Operating Unit' in Sales Order

### DIFF
--- a/sale_operating_unit/__manifest__.py
+++ b/sale_operating_unit/__manifest__.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Operating Unit in Sales",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "summary": "An operating unit (OU) is an organizational entity part of a "
     "company",
     "author": "ForgeFlow, "

--- a/sale_operating_unit/models/sale_order.py
+++ b/sale_operating_unit/models/sale_order.py
@@ -21,6 +21,7 @@ class SaleOrder(models.Model):
         string="Operating Unit",
         default=_default_operating_unit,
         readonly=True,
+        index=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )
 


### PR DESCRIPTION
Probably this can't be generalised, but in the project I'm
optimising right now, after a profiling of the SQLs thrown
by Odoo, adding an index here resulted in a speed-up of
almost X4. So I add the index.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119559">[t119559] [mt11703] Small Changes Needed in Frepple</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sale_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->