### PR TITLE
[bt#12546] Bugfixing assignment of operating unit for pickings coming…

### DIFF
--- a/sale_stock_operating_unit/models/stock_move.py
+++ b/sale_stock_operating_unit/models/stock_move.py
@@ -13,7 +13,8 @@ class StockMove(models.Model):
         Override to add Operating Units to Picking.
         """
         values = super(StockMove, self)._get_new_picking_values()
-
-        values.update({"operating_unit_id": self.sale_line_id.operating_unit_id.id})
+        # Adding operating_unit_id as for 2 steps deliveries/receipts,
+        # one of the pickings is not associated to the sale line
+        values.update({"operating_unit_id": self.sale_line_id.operating_unit_id.id or self.operating_unit_id.id})
 
         return values


### PR DESCRIPTION
… from moves. It con come from the sale_line_id or from the own operating unit assigned to the move, as sometimes for instance, for two level deliveries, the sale_line_id is assigned to move from Output > Customers, but not to the other first move Stock > Output

No need for update

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12546">[bt#12546] [mt#982] sale_order_lot_selection: Doesn't Work for Multi-Step Delivery Route</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sale_stock_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->