### PR TITLE
[bt#15878] Add operating unit on hr expense creation if possible so

### DIFF
--- a/hr_expense_operating_unit/models/hr_expense.py
+++ b/hr_expense_operating_unit/models/hr_expense.py
@@ -111,3 +111,13 @@ class HrExpenseSheet(models.Model):
                 the Expense and in the Operating Unit must be the same"""
                     )
                 )
+
+    @api.model
+    def create(self, vals):
+        lines = vals.get('expense_line_ids', False)
+        if lines and lines[0][0] == 6:
+            hr_expenses = self.env['hr.expense'].browse(lines[0][2])
+            operating_unit = hr_expenses.mapped('operating_unit_id')
+            if len(operating_unit) == 1:
+                vals['operating_unit_id'] = operating_unit.id
+        return super(HrExpenseSheet, self).create(vals)


### PR DESCRIPTION
the default doesn't trigger unless really needed

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=15878">[bt#15878] MIUS Staging Business Test: Expense Report Creation Error</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>hr_expense_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->