### PR TITLE
[t121075] Fixes _onchange_operating_unit_id by adding limit=1 to search call

### DIFF
--- a/mrp_operating_unit/models/mrp.py
+++ b/mrp_operating_unit/models/mrp.py
@@ -47,7 +47,9 @@ class MrpProduction(models.Model):
     @api.onchange("operating_unit_id")
     def _onchange_operating_unit_id(self):
         """Change locations according to the warehouse of the operating unit"""
-        if not self.operating_unit_id:
+        if (not self.operating_unit_id
+            or not self.picking_type_id.warehouse_id.operating_unit_id
+            or self.picking_type_id.warehouse_id.operating_unit_id.id == self.operating_unit_id.id):
             return
 
         # Take first warehouse with the current operating unit
@@ -62,7 +64,18 @@ class MrpProduction(models.Model):
                 ("code", "=", "mrp_operation"),
                 ("company_id", "=", self.company_id.id),
                 ("warehouse_id", "=", wh.id),
-            ]
+            ], limit=1
         )
         if picking_type_id:
             self.picking_type_id = picking_type_id
+
+    @api.onchange("picking_type_id")
+    def onchange_picking_type(self):
+        res = super(MrpProduction, self).onchange_picking_type()
+
+        picking_type_operating_unit = self.picking_type_id.warehouse_id.operating_unit_id
+
+        if picking_type_operating_unit.id != self.operating_unit_id.id:
+            self.operating_unit_id = picking_type_operating_unit
+
+        return res


### PR DESCRIPTION
Improves general onchange management.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=121075">[t121075] Alt. UoM: Enable in Manufacturing Orders</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>mrp_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->