### PR TITLE
[t126547] Adding onchange for picking type in PO so that if it change, the operating unit and requesting operating unit are changed accordingly

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -93,12 +93,17 @@ class PurchaseOrder(models.Model):
                     )
                 )
 
-    @api.onchange('picking_type_id')
+    @api.onchange("picking_type_id")
     def _onchange_picking_type_id(self):
         res = super()._onchange_picking_type_id()
         if self.picking_type_id:
-            if self.picking_type_id.warehouse_id.operating_unit_id.id != self.operating_unit_id.id:
-                self.operating_unit_id = self.picking_type_id.warehouse_id.operating_unit_id
+            if (
+                self.picking_type_id.warehouse_id.operating_unit_id.id
+                != self.operating_unit_id.id
+            ):
+                self.operating_unit_id = (
+                    self.picking_type_id.warehouse_id.operating_unit_id
+                )
         return res
 
     @api.onchange("operating_unit_id")

--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -95,9 +95,11 @@ class PurchaseOrder(models.Model):
 
     @api.onchange('picking_type_id')
     def _onchange_picking_type_id(self):
-        super()._onchange_picking_type_id()
-        self.operating_unit_id = self.picking_type_id.warehouse_id.operating_unit_id
-        self.requesting_operating_unit_id = self.picking_type_id.warehouse_id.operating_unit_id
+        res = super()._onchange_picking_type_id()
+        if self.picking_type_id:
+            if self.picking_type_id.warehouse_id.operating_unit_id.id != self.operating_unit_id.id:
+                self.operating_unit_id = self.picking_type_id.warehouse_id.operating_unit_id
+        return res
 
     @api.onchange("operating_unit_id")
     def _onchange_operating_unit_id(self):

--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -93,6 +93,12 @@ class PurchaseOrder(models.Model):
                     )
                 )
 
+    @api.onchange('picking_type_id')
+    def _onchange_picking_type_id(self):
+        super()._onchange_picking_type_id()
+        self.operating_unit_id = self.picking_type_id.warehouse_id.operating_unit_id
+        self.requesting_operating_unit_id = self.picking_type_id.warehouse_id.operating_unit_id
+
     @api.onchange("operating_unit_id")
     def _onchange_operating_unit_id(self):
         type_obj = self.env["stock.picking.type"]


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=126547">[t126547] [mt12959] frePPLe Connector Out- & Inbound: Multi-Warehouse MO & Set Operating Unit Based on Warehouse for PO & MO (Operating Unit Bridge Module)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>purchase_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->