### PR TITLE
[t130202] Fixing wrong migration to v13 for extension of _prepare_pu…

### DIFF
--- a/purchase_operating_unit/models/stock_rule.py
+++ b/purchase_operating_unit/models/stock_rule.py
@@ -6,11 +6,12 @@ class StockRule(models.Model):
     _inherit = "stock.rule"
 
     def _prepare_purchase_order(self, company_id, origins, values):
-        res = super()._prepare_purchase_order(company_id, origins, values)
-        if origins and "SO" in origins:
+        res = super(StockRule, self)._prepare_purchase_order(
+            company_id, origins, values)
+        if origins and len(origins) == 1 and 'SO' in list(origins)[0]:
             operating_unit = (
                 self.env["sale.order"]
-                .search([("name", "=", origins)])
+                .search([('name', '=', list(origins)[0])])
                 .warehouse_id.operating_unit_id
             )
 


### PR DESCRIPTION
…rchase_order in stock_rule to set the operating unit in the PO created from a SO (dropshipping)

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec.com/web#view_type=form&model=project.task&id=130202">[t130202] MIDE DEV V15 Migration - Operating Unit (OCA & BT) - Part 2</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>purchase_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->