### PR TITLE
[t128046] fix return

### DIFF
--- a/product_operating_unit/models/product_template.py
+++ b/product_operating_unit/models/product_template.py
@@ -64,7 +64,7 @@ class ProductTemplate(models.Model):
             _logger.info("%s" % (ou_id.name))
             category = self.env["product.category"].search([], limit=1)
             if category:
-                return category.id
+                return category
             else:
                 try:
                     self.env.ref(


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec.com/web#view_type=form&model=project.task&id=128046">[t128046] GEP Textile and Cosmetics - no overarching planning (operating unit)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>product_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->