### PR TITLE
[t132190] Fixed warnings appearing due to incomplete migration

### DIFF
--- a/crm_operating_unit/models/crm_lead.py
+++ b/crm_operating_unit/models/crm_lead.py
@@ -19,5 +19,4 @@ class CRMLead(models.Model):
         "operating.unit",
         "Operating Unit",
         related="team_id.operating_unit_id",
-        default=_get_default_operating_unit,
     )


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://www.braintec.com/web#view_type=form&model=project.task&id=132190">[t132190] MIDE DEV V15 - Fix Warnings due to Incomplete Migrations</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>crm_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->