### PR TITLE
[t154870] Fix Operating Unit Missing on Journal Entry on Inventory Adjustment

### DIFF
--- a/stock_account_operating_unit/tests/test_stock_account_operating_unit.py
+++ b/stock_account_operating_unit/tests/test_stock_account_operating_unit.py
@@ -368,3 +368,15 @@ class TestStockAccountOperatingUnit(TestStockCommon):
             operating_unit=None,
             expected_balance=expected_balance,
         )
+        # Check if the OU is set in the resulting move
+        # The same operating unit must be set in the account.move
+        # related to this inventory adjustment.
+        self.quant_id.inventory_quantity = 5
+        self.quant_id.action_apply_inventory()
+        move = self.env["account.move"].search(
+            [("ref", "ilike", "% - test_product")],
+            limit=1,
+            order="create_date desc",
+        )
+        self.assertTrue(move.exists())
+        self.assertEqual(move.operating_unit_id, self.ou1)


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=154870">[t154870] [DEV] Fix Operating Unit Missing on Journal Entry on Inventory Adjustment</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_account_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->