### PR TITLE
[t154870] Fixed double entry by removing OCA code

### DIFF
--- a/stock_account_operating_unit/model/stock_move.py
+++ b/stock_account_operating_unit/model/stock_move.py
@@ -73,58 +73,6 @@ class StockMove(models.Model):
             return rslt
         return res
 
-    def _action_done(self, cancel_backorder=False):
-        """
-        Generate accounting moves if the product being moved is subject
-        to real_time valuation tracking,
-        and the source or destination location are
-        a transit location or is outside of the company or the source or
-        destination locations belong to different operating units.
-        """
-        res = super()._action_done(cancel_backorder)
-        for move in self:
-            if move.product_id.valuation == "real_time":
-                # Inter-operating unit moves do not accept to
-                # from/to non-internal location
-                if (
-                    move.location_id.company_id
-                    and move.location_id.company_id == move.location_dest_id.company_id
-                    and move.operating_unit_id != move.operating_unit_dest_id
-                ):
-                    (
-                        journal_id,
-                        acc_src,
-                        acc_dest,
-                        acc_valuation,
-                    ) = move._get_accounting_data_for_valuation()
-
-                    move_lines = move._prepare_account_move_line(
-                        move.product_qty,
-                        move.product_id.standard_price,
-                        acc_valuation,
-                        acc_valuation,
-                        False,
-                        _("%s - OU Move") % move.product_id.display_name,
-                    )
-                    am = (
-                        self.env["account.move"]
-                        .with_context(
-                            company_id=move.company_id.id,
-                        )
-                        .create(
-                            {
-                                "journal_id": journal_id,
-                                "line_ids": move_lines,
-                                "company_id": move.company_id.id,
-                                "ref": move.picking_id and move.picking_id.name,
-                                "stock_move_id": move.id,
-                            }
-                        )
-                        .with_company(move.location_id.company_id.id)
-                    )
-                    am.action_post()
-            return res
-
     def _account_entry_move(self, qty, description, svl_id, cost):
         res = super()._account_entry_move(qty, description, svl_id, cost)
         operating_unit = self.operating_unit_dest_id or self.operating_unit_id

--- a/stock_account_operating_unit/tests/test_stock_account_operating_unit.py
+++ b/stock_account_operating_unit/tests/test_stock_account_operating_unit.py
@@ -348,14 +348,14 @@ class TestStockAccountOperatingUnit(TestStockCommon):
             expected_balance=expected_balance,
         )
         # GL account ‘Inventory’ has balance 0 on OU main_operating_unit
-        expected_balance = 0.0
+        expected_balance = 1.0
         self._check_account_balance(
             self.account_inventory.id,
             operating_unit=self.ou1,
             expected_balance=expected_balance,
         )
         # GL account ‘Inventory’ has balance 2 on OU b2c
-        expected_balance = 2.0
+        expected_balance = 1.0
         self._check_account_balance(
             self.account_inventory.id,
             operating_unit=self.b2c,


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=154870">[t154870] [DEV] Fix Operating Unit Missing on Journal Entry on Inventory Adjustment</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_account_operating_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->